### PR TITLE
Fix missing button style

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -2,7 +2,9 @@ import React from 'react';
 import styles from './Button.module.css';
 import whatsIcon from '../../assets/icons/whatsIcon.svg';
 
-const Button = ({ children, href = "#", variant = 'primary', hasIcon = false, className = '' }) => {
+// Default variant was "primary" but no corresponding style existed.
+// Use the existing "whatsapp" style as the default to avoid undefined classes.
+const Button = ({ children, href = "#", variant = 'whatsapp', hasIcon = false, className = '' }) => {
   return (
     <a
       href={href}


### PR DESCRIPTION
## Summary
- use the existing `whatsapp` style as the default button variant

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876962712fc8324a7dc3a95d61b53af